### PR TITLE
do not use utils in ghost src

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "ghost-oss-store",
+  "version": "1.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "unidecode": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/unidecode/-/unidecode-0.1.8.tgz",
+      "integrity": "sha1-77swFTi8RSRqmsjFWdcvAVMFBT4="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "ali-oss": "^4.4.4",
     "bluebird": "^3.4.6",
-    "ghost-storage-base": "^0.0.1"
+    "ghost-storage-base": "^0.0.1",
+    "unidecode": "^0.1.8"
   }
 }


### PR DESCRIPTION
I found there is no `ghost/core/server/utils.js` in new version.

we just need it's `saveString` function, so I copy it from old version. and remove the deps.

BTW, `saveString` need the `unidecode` package.
